### PR TITLE
Support email-gated Papermark links via --email flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ if __name__ == '__main__':
     parser.add_argument('-r', '--resolution', help='The slide resolution, HD, 4K or 8K allowed', default='4K')
     parser.add_argument('--disable-headless', action='store_true', dest='disable_headless', help='Disable headless mode')
     parser.add_argument('--skip-ocr', action='store_true', dest='skip_ocr', help='Disable OCR')
+    parser.add_argument('--email', help='Email to submit if a Papermark link is gated')
     args = parser.parse_args()
 
     # Warn if Tesseract is missing and OCR is enabled
@@ -35,7 +36,7 @@ if __name__ == '__main__':
 
     # Saving the presentation as a PDF
     try:
-        sd = SlideDownloader(args.resolution, args.disable_headless)
+        sd = SlideDownloader(args.resolution, args.disable_headless, email=args.email)
         pdf_path = sd.download(url)
     except Exception as e:
         print(f"Error: {e}")

--- a/utils/slide_downloader.py
+++ b/utils/slide_downloader.py
@@ -12,8 +12,9 @@ from utils import sources
 
 class SlideDownloader:
 
-    def __init__(self, resolution, disable_headless):
+    def __init__(self, resolution, disable_headless, email=None):
 
+        self.email = email
         chrome_options = Options()
         
         if not disable_headless:
@@ -151,7 +152,7 @@ class SlideDownloader:
         elif 'figma.com/deck' in self.driver.current_url.lower():
             return 'figma', sources.get_figma_params(self.driver)
         elif 'papermark.com' in self.driver.current_url.lower():
-            return 'papermark', sources.get_papermark_params(self.driver)
+            return 'papermark', sources.get_papermark_params(self.driver, email=self.email)
 
         raise Exception('URL not supported...')
 

--- a/utils/sources.py
+++ b/utils/sources.py
@@ -132,10 +132,30 @@ def get_figma_params(driver):
 
     )
 
-def get_papermark_params(driver):
+def get_papermark_params(driver, email=None):
     '''
-    Preprocesses Papermark and returns params to find all slides
+    Preprocesses Papermark and returns params to find all slides.
+    If the deck is gated behind an email prompt, `email` is submitted.
     '''
+    # Email gate: some Papermark links require an email before showing the deck
+    email_inputs = driver.find_elements(By.CSS_SELECTOR, 'input[type="email"]')
+    if email_inputs:
+        if not email:
+            raise Exception(
+                'This Papermark link requires an email to view. '
+                'Re-run with --email <addr>.'
+            )
+        email_inputs[0].send_keys(email)
+        for b in driver.find_elements(By.TAG_NAME, 'button'):
+            if b.text.strip() in ('Continue', 'Submit'):
+                b.click()
+                break
+        # Wait for the slide counter to appear instead of a fixed sleep
+        for _ in range(30):
+            if driver.find_elements(By.CSS_SELECTOR, 'div.bg-gray-900.text-white span'):
+                break
+            time.sleep(0.5)
+
     spans = driver.find_elements(By.CSS_SELECTOR, 'div.bg-gray-900.text-white span')
     n_slides = int(spans[-1].text) - 1
     next_btn = driver.find_element(By.CSS_SELECTOR, 'div.group.absolute.right-0 button')


### PR DESCRIPTION
## Summary

Some Papermark links require visitors to enter an email before the deck is rendered. The current handler crashes on those links with:

```
Error: list index out of range
```

…because `get_papermark_params` queries the slide-counter element before it exists in the DOM.

This PR:

- Adds a `--email <addr>` flag to `main.py`.
- Threads it through `SlideDownloader.__init__` to `sources.get_papermark_params`.
- When the email gate is detected (an `input[type="email"]` is present on the page), submits the email and clicks the Continue/Submit button.
- Polls for the slide counter to appear (up to 15s) instead of using a fixed sleep — faster and more reliable.
- Raises a clear error if the gate is detected but `--email` wasn't passed, instead of the cryptic `IndexError`.

Non-gated Papermark links keep working unchanged (the email block is skipped when no `input[type="email"]` is found).

## Test plan

- [x] Gated link with `--email viewer@example.com --skip-ocr` → 15-page PDF saved successfully.
- [x] Gated link without `--email` → clean error: `This Papermark link requires an email to view. Re-run with --email <addr>.`
- [ ] Non-gated Papermark link still works (no gated public link handy to verify against — would appreciate a maintainer sanity-check here).
- [ ] Other platforms (pitch.com / canva / gslides / figma) are untouched and unaffected.